### PR TITLE
JI: 561237 - [CAR2.2] Application Launching: "Show me a map of Montréal"

### DIFF
--- a/plugin/com.qnx.application.event/src/blackberry10/application.js
+++ b/plugin/com.qnx.application.event/src/blackberry10/application.js
@@ -88,23 +88,15 @@ function onCommand(event) {
 };
 
 /**
- * Method called when opened pps object ready
- * Contains data from opened PPS obect
- * @param event {Object} content the appdata object
- */
-function onAppDataReady(event) {
-	if (_appdataTrigger && event && event[_key]) {
-		_appdataTrigger(event[_key]);
-	}
-}
-
-/**
  * Method called when app data received
  * @param event {Object} The PPS event for the appdata object
  */
 function onAppData(event) {
-	if (_appdataTrigger && event && event.data && event.data[_key]) {
-		_appdataTrigger(event.data[_key]);
+	if (_appdataTrigger && event) {
+		var appLauncherData = event["app-launcher"];
+		if (appLauncherData && appLauncherData.req && appLauncherData.req.app && appLauncherData.req.dat && appLauncherData.req.app === _key) {
+				_appdataTrigger(appLauncherData.req.dat);
+		}
 	}
 }
 
@@ -128,8 +120,8 @@ module.exports = {
 		}
 		//listen for startup arguments
 		if (typeof _appdataReaderPPS === "undefined") {
-			_appdataReaderPPS = _pps.create("/pps/system/navigator/appdata", _pps.PPSMode.DELTA);
-			_appdataReaderPPS.onFirstReadComplete = onAppDataReady;
+			_appdataReaderPPS = _pps.create("/pps/services/app-launcher", _pps.PPSMode.FULL);
+			_appdataReaderPPS.onFirstReadComplete = onAppData;
 			_appdataReaderPPS.onNewData = onAppData;
 			_appdataReaderPPS.open(_pps.FileMode.RDONLY);
 		}


### PR DESCRIPTION
JI: 660071
RB: http://reviews.ott.qnx.com/r/139158/
CI: lgreenway

Description:
- Fixed problem with accented characters not getting rendered properly by making the PPS object being watched return the full value instead of just the delta.
- Changed the PPS object for getting appdata to use the /pps/services/app-launcher object, since the app data is already being written there. This in turn requires no changes from the HMI side.

Testing Done:
Built and installed LocalSearch bar file with this changed made. Verified that accented characters appeared correctly as a result of an ASR command:

echo strobe::start://Weather in Montréal >> /pps/services/asr/control

Also verified that the LocalSearch app is actually launched with these parameters.